### PR TITLE
Bring x3p0 plugin and add styles

### DIFF
--- a/legacy-features-fse.php
+++ b/legacy-features-fse.php
@@ -26,8 +26,6 @@ namespace WP_Syntex\Legacy_Features_for_FSE;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'LFFF_DIR', __DIR__ );
-
 define( 'LFFF_FILE', __FILE__ );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/legacy-features-fse.php
+++ b/legacy-features-fse.php
@@ -19,7 +19,11 @@
  * License:           GPL v3 or later
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.txt
  *
- * Copyright 2021 WP SYNTEX
+ * Copyright 2022 WP SYNTEX
+ *
+ * This program incorporates work from the plugin Legacy Widget Block
+ * Copyright 2022 Justin Tadlock (email : justintadlock@gmail.com)
+ * Legacy Widget Block is released under the GPL V2 or later.
  */
 
 namespace WP_Syntex\Legacy_Features_for_FSE;

--- a/legacy-features-fse.php
+++ b/legacy-features-fse.php
@@ -26,6 +26,10 @@ namespace WP_Syntex\Legacy_Features_for_FSE;
 
 defined( 'ABSPATH' ) || exit;
 
+define( 'LFFF_DIR', __DIR__ );
+
+define( 'LFFF_FILE', __FILE__ );
+
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }

--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -1,0 +1,40 @@
+.wp-block-legacy-widget-inspector-card {
+	padding: 16px;
+}
+
+.wp-block-legacy-widget__edit-form {
+	-moz-font-smoothing: subpixel-antialiased;
+	-webkit-font-smoothing: subpixel-antialiased;
+	background-color: #fff;
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px #1e1e1e;
+	box-sizing: border-box;
+	color: #1e1e1e;
+	margin: 0;
+	min-height: 200px;
+	outline: 1px solid transparent;
+	padding: 1em;
+	position: relative;
+	text-align: left;
+	width: 100%;
+}
+
+.wp-block-legacy-widget__edit-form-title {
+	font-size: 18pt;
+	font-weight: 400;
+	align-items: center;
+	display: flex;
+	margin-bottom: 16px;
+}
+
+.wp-block-legacy-widget__edit-preview {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+}
+
+.wp-block-legacy-widget__edit-preview-iframe {
+	box-sizing: border-box;
+	width: 100%;
+	border: none;
+}

--- a/public/css/menu.css
+++ b/public/css/menu.css
@@ -1,0 +1,36 @@
+.widget_nav_menu .menu {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    width: 100%;
+    text-align: left;
+}
+
+.widget_nav_menu .menu ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	position: absolute;
+	left: -999em;
+}
+
+.widget_nav_menu .menu li {
+    display: inline-block;
+    position: relative;
+    text-align: left;
+    padding-right: var(--wp--style--block-gap, 2em);
+}
+
+.widget_nav_menu .menu li:hover > ul {
+    left: auto;
+}
+
+.widget_nav_menu .menu li li {
+	display: block;
+	width: 100%;
+}
+
+.widget_nav_menu .menu li li:hover > ul {
+    left: 100%;
+    top: 0;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,37 @@
+.wp-block-legacy-widget__edit-form {
+	-moz-font-smoothing: subpixel-antialiased;
+	-webkit-font-smoothing: subpixel-antialiased;
+	background-color: #fff;
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px #1e1e1e;
+	box-sizing: border-box;
+	color: #1e1e1e;
+	margin: 0;
+	min-height: 200px;
+	outline: 1px solid transparent;
+	padding: 1em;
+	position: relative;
+	text-align: left;
+	width: 100%;
+}
+
+.wp-block-legacy-widget__edit-form-title {
+	font-size: 18pt;
+	font-weight: 400;
+	align-items: center;
+	display: flex;
+	margin-bottom: 16px;
+}
+
+.wp-block-legacy-widget__edit-form + .wp-block-legacy-widget__edit-preview {
+	margin-top: 1rem;
+	background-color: transparent;
+	border: none;
+	box-shadow: none;
+}
+
+.wp-block-legacy-widget__edit-preview-iframe {
+	box-sizing: border-box;
+	width: 100%;
+	border: none;
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -130,7 +130,7 @@ final class Plugin {
 	 */
 	public function adminStyles() {
 		if ( $this->isBlockEditor() ) {
-			do_action( 'admin_print_styles-widgets.php' );
+			do_action( 'admin_print_styles-widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 	}
 
@@ -143,10 +143,10 @@ final class Plugin {
 	 */
 	public function adminScripts() {
 		if ( $this->isBlockEditor() ) {
-			do_action( 'load-widgets.php' );
-			do_action( 'widgets.php' );
+			do_action( 'load-widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+			do_action( 'widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			do_action( 'sidebar_admin_setup' );
-			do_action( 'admin_print_scripts-widgets.php' );
+			do_action( 'admin_print_scripts-widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 	}
 
@@ -159,7 +159,7 @@ final class Plugin {
 	 */
 	public function adminFooterScripts() {
 		if ( $this->isBlockEditor() ) {
-			do_action( 'admin_print_footer_scripts-widgets.php' );
+			do_action( 'admin_print_footer_scripts-widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 	}
 
@@ -172,7 +172,7 @@ final class Plugin {
 	 */
 	public function adminFooterWidgets() {
 		if ( $this->isBlockEditor() ) {
-			do_action( 'admin_footer-widgets.php' );
+			do_action( 'admin_footer-widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,7 +86,7 @@ final class Plugin {
 		add_action( 'wp_enqueue_scripts', [ $this, 'classicMenuStyles' ] );
 		add_action( 'admin_init', [ $this, 'addEditorStyles' ] );
 		add_action( 'admin_print_scripts', [ $this, 'adminScripts' ] );
-		add_action( 'admin_print_footer_scripts', [ $this, 'adminFooterScripts'] );
+		add_action( 'admin_print_footer_scripts', [ $this, 'adminFooterScripts' ] );
 		add_action( 'admin_footer', [ $this, 'adminFooterWidgets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'editorAssets' ] );
 		add_action( 'after_setup_theme', [ $this, 'supportMenusAndWidgets' ] );
@@ -147,7 +147,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminStyles() {
-		if ( get_current_screen()->is_block_editor() ) {
+		if ( $this->is_block_editor() ) {
 			do_action( 'admin_print_styles-widgets.php' );
 		}
 	}
@@ -160,7 +160,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminScripts() {
-		if ( get_current_screen()->is_block_editor() ) {
+		if ( $this->is_block_editor() ) {
 			do_action( 'load-widgets.php' );
 			do_action( 'widgets.php' );
 			do_action( 'sidebar_admin_setup' );
@@ -176,7 +176,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminFooterScripts() {
-		if ( get_current_screen()->is_block_editor() ) {
+		if ( $this->is_block_editor() ) {
 			do_action( 'admin_print_footer_scripts-widgets.php' );
 		}
 	}
@@ -189,7 +189,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminFooterWidgets() {
-		if ( get_current_screen()->is_block_editor() ) {
+		if ( $this->is_block_editor() ) {
 			do_action( 'admin_footer-widgets.php' );
 		}
 	}
@@ -203,5 +203,22 @@ final class Plugin {
 	 */
 	public function supportMenusAndWidgets() {
 		add_theme_support( 'menus' );
+	}
+
+	/**
+	 * Check if the current screen runs the block editor.
+	 *
+	 * @since 1.0
+	 *
+	 * @return boolean True if the current screen runs the block editor, false otherwise.
+	 */
+	private function is_block_editor() {
+		$current_screen = get_current_screen();
+
+		if ( ! empty( $current_screen ) ) {
+			return $current_screen->is_block_editor();
+		}
+
+		return false;
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -129,7 +129,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminStyles() {
-		if ( $this->is_block_editor() ) {
+		if ( $this->isBlockEditor() ) {
 			do_action( 'admin_print_styles-widgets.php' );
 		}
 	}
@@ -142,7 +142,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminScripts() {
-		if ( $this->is_block_editor() ) {
+		if ( $this->isBlockEditor() ) {
 			do_action( 'load-widgets.php' );
 			do_action( 'widgets.php' );
 			do_action( 'sidebar_admin_setup' );
@@ -158,7 +158,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminFooterScripts() {
-		if ( $this->is_block_editor() ) {
+		if ( $this->isBlockEditor() ) {
 			do_action( 'admin_print_footer_scripts-widgets.php' );
 		}
 	}
@@ -171,7 +171,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function adminFooterWidgets() {
-		if ( $this->is_block_editor() ) {
+		if ( $this->isBlockEditor() ) {
 			do_action( 'admin_footer-widgets.php' );
 		}
 	}
@@ -194,7 +194,7 @@ final class Plugin {
 	 *
 	 * @return boolean True if the current screen runs the block editor, false otherwise.
 	 */
-	private function is_block_editor() {
+	private function isBlockEditor() {
 		$current_screen = get_current_screen();
 
 		if ( ! empty( $current_screen ) ) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,6 +25,24 @@ final class Plugin {
 	const VERSION = '1.0';
 
 	/**
+	 * The plugin URL.
+	 *
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->url = plugin_dir_url( LFFF_FILE );
+	}
+
+	/**
 	 * Plugin init.
 	 *
 	 * @since 1.0
@@ -61,5 +79,114 @@ final class Plugin {
 	 * @return void
 	 */
 	private function addHooks() {
+		add_action( 'admin_print_styles', [ $this, 'adminStyles' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'classicMenuStyles' ] );
+		add_action( 'admin_init', [ $this, 'addEditorStyles' ] );
+		add_action( 'admin_print_scripts', [ $this, 'adminScripts' ] );
+		add_action( 'admin_print_footer_scripts', [ $this, 'adminFooterScripts'] );
+		add_action( 'admin_footer', [ $this, 'adminFooterWidgets' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'editorAssets' ] );
+	}
+
+	/**
+	 * Loads the widget scripts and registers the Legacy Widget block via JS.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function editorAssets() {
+		wp_enqueue_script( 'wp-widgets' );
+		wp_add_inline_script( 'wp-widgets', 'wp.widgets.registerLegacyWidgetBlock()' );
+
+		// Editor stylesheet.
+		wp_enqueue_style(
+			'legacy-features-for-fse-widget-editor',
+			$this->url . '/public/css/editor.css',
+			[],
+			self::VERSION
+		);
+	}
+
+	/**
+	 * Loads the classic menu style.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function classicMenuStyles() {
+		wp_enqueue_style(
+			'legacy-features-for-fse-classic-menu',
+			$this->url . '/public/css/menu.css',
+			[],
+			self::VERSION
+		);
+	}
+
+	/**
+	 * Loads editor style for cleaning up the block design.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function addEditorStyles() {
+		add_editor_style( [ $this->url . '/public/css/style.css' ] );
+	}
+
+	/**
+	 * Runs the widget styles action in the block editor.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function adminStyles() {
+		if ( get_current_screen()->is_block_editor() ) {
+			do_action( 'admin_print_styles-widgets.php' );
+		}
+	}
+
+	/**
+	 * Runs various widget actions in the block editor.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function adminScripts() {
+		if ( get_current_screen()->is_block_editor() ) {
+			do_action( 'load-widgets.php' );
+			do_action( 'widgets.php' );
+			do_action( 'sidebar_admin_setup' );
+			do_action( 'admin_print_scripts-widgets.php' );
+		}
+	}
+
+	/**
+	 * Runs the footer widget scripts action in the block editor.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function adminFooterScripts() {
+		if ( get_current_screen()->is_block_editor() ) {
+			do_action( 'admin_print_footer_scripts-widgets.php' );
+		}
+	}
+
+	/**
+	 * Runs the widgets footer action in the block editor.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function adminFooterWidgets() {
+		if ( get_current_screen()->is_block_editor() ) {
+			do_action( 'admin_footer-widgets.php' );
+		}
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -195,7 +195,7 @@ final class Plugin {
 	}
 
 	/**
-	 * Allows to display the menus and widgets admin pages.
+	 * Allows to display the menus admin page.
 	 *
 	 * @since 1.0
 	 *
@@ -203,6 +203,5 @@ final class Plugin {
 	 */
 	public function supportMenusAndWidgets() {
 		add_theme_support( 'menus' );
-		add_theme_support( 'widgets' );
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,6 +86,7 @@ final class Plugin {
 		add_action( 'admin_print_footer_scripts', [ $this, 'adminFooterScripts'] );
 		add_action( 'admin_footer', [ $this, 'adminFooterWidgets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'editorAssets' ] );
+		add_action( 'after_setup_theme', [ $this, 'supportMenusAndWidgets' ] );
 	}
 
 	/**
@@ -188,5 +189,17 @@ final class Plugin {
 		if ( get_current_screen()->is_block_editor() ) {
 			do_action( 'admin_footer-widgets.php' );
 		}
+	}
+
+	/**
+	 * Allows to display the menus and widgets admin pages.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function supportMenusAndWidgets() {
+		add_theme_support( 'menus' );
+		add_theme_support( 'widgets' );
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,24 +25,6 @@ final class Plugin {
 	const VERSION = '1.0';
 
 	/**
-	 * The plugin URL.
-	 *
-	 * @var string
-	 */
-	private $url;
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 1.0
-	 *
-	 * @return void
-	 */
-	public function __construct() {
-		$this->url = plugin_dir_url( LFFF_FILE );
-	}
-
-	/**
 	 * Plugin init.
 	 *
 	 * @since 1.0
@@ -106,7 +88,7 @@ final class Plugin {
 		// Editor stylesheet.
 		wp_enqueue_style(
 			'legacy-features-for-fse-widget-editor',
-			$this->url . '/public/css/editor.css',
+			plugins_url( '/public/css/editor.css', LFFF_FILE ),
 			[],
 			self::VERSION
 		);
@@ -122,7 +104,7 @@ final class Plugin {
 	public function classicMenuStyles() {
 		wp_enqueue_style(
 			'legacy-features-for-fse-classic-menu',
-			$this->url . '/public/css/menu.css',
+			plugins_url( '/public/css/menu.css', LFFF_FILE ),
 			[],
 			self::VERSION
 		);
@@ -136,7 +118,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function addEditorStyles() {
-		add_editor_style( [ $this->url . '/public/css/style.css' ] );
+		add_editor_style( [ plugins_url( '/public/css/style.css', LFFF_FILE ) ] );
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -59,7 +59,10 @@ final class Plugin {
 		 */
 		do_action_ref_array( 'legacy_features_for_fse_before_init', [ &$this ] );
 
-		$this->addHooks();
+		if ( wp_is_block_theme() ) {
+			// Loads the plugin only if the theme is a block theme.
+			$this->addHooks();
+		}
 
 		/**
 		 * Fires after the plugin init.


### PR DESCRIPTION
This PR bring some code from x3p0 plugin to be able to use classic menu widget in the Site Editor.
Also add some style, so our language switcher is well rendered both on front and on admin.
Loads properly the plugin only if the current theme is a block theme.
Allows to display the old menu edition page.