### PR TITLE
Simplify editorAssets()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -101,18 +101,7 @@ final class Plugin {
 	public function editorAssets() {
 		wp_enqueue_script( 'wp-widgets' );
 		wp_add_inline_script( 'wp-widgets', 'wp.widgets.registerLegacyWidgetBlock()' );
-
-		if ( is_rtl() ) {
-			wp_enqueue_style(
-				'widget-editor-core-style',
-				home_url( '/wp-includes/css/dist/widgets/style-rtl.css' )
-			);
-		} else {
-			wp_enqueue_style(
-				'widget-editor-core-style',
-				home_url( '/wp-includes/css/dist/widgets/style.css' )
-			);
-		}
+		wp_enqueue_style( 'wp-widgets' );
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -99,24 +99,18 @@ final class Plugin {
 	 * @return void
 	 */
 	public function editorAssets() {
-		$wp_version = get_bloginfo( ' version' );
-
 		wp_enqueue_script( 'wp-widgets' );
 		wp_add_inline_script( 'wp-widgets', 'wp.widgets.registerLegacyWidgetBlock()' );
 
 		if ( is_rtl() ) {
 			wp_enqueue_style(
 				'widget-editor-core-style',
-				home_url( '/wp-includes/css/dist/widgets/style-rtl.css' ),
-				[],
-				$wp_version
+				home_url( '/wp-includes/css/dist/widgets/style-rtl.css' )
 			);
 		} else {
 			wp_enqueue_style(
 				'widget-editor-core-style',
-				home_url( '/wp-includes/css/dist/widgets/style.css' ),
-				[],
-				$wp_version
+				home_url( '/wp-includes/css/dist/widgets/style.css' )
 			);
 		}
 	}


### PR DESCRIPTION
`wp_enqueue_style()` adds the WordPress version by default so it's useless to add it ourselves. See https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters